### PR TITLE
Various fixes

### DIFF
--- a/samples/apps/emailsettings_pop_settings.py
+++ b/samples/apps/emailsettings_pop_settings.py
@@ -131,7 +131,7 @@ def main():
       raise PopSettingsException('Invalid consumer credentials')
     elif e.status == 503:
       raise PopSettingsException('Server busy')
-    else e.status == 500:
+    elif e.status == 500:
       raise PopSettingsException('Internal server error')
     else:
       raise PopSettingsException('Unknown error')

--- a/src/gdata/service.py
+++ b/src/gdata/service.py
@@ -1085,7 +1085,7 @@ class GDataService(atom.service.AtomService):
           return result_body
         return entry
       return feed
-    elif server_response.status == 302:
+    elif server_response.status in (301, 302):
       if redirects_remaining > 0:
         location = (server_response.getheader('Location')
                     or server_response.getheader('location'))

--- a/tests/module_test_runner.py
+++ b/tests/module_test_runner.py
@@ -41,7 +41,7 @@ class ModuleTestRunner(object):
     It also sets any module variables which match the settings keys to the
     corresponding values in the settings member.
     """
-    runner = unittest.TextTestRunner()
+    runner = unittest.TextTestRunner(verbosity=2)
     for module in self.modules:
       # Set any module variables according to the contents in the settings
       for setting, value in self.settings.iteritems():
@@ -53,5 +53,6 @@ class ModuleTestRunner(object):
           pass
       # We have set all of the applicable settings for the module, now
       # run the tests.
-      print '\nRunning all tests in module', module.__name__
-      runner.run(unittest.defaultTestLoader.loadTestsFromModule(module))    
+      result = runner.run(unittest.defaultTestLoader.loadTestsFromModule(module))
+      if not result.wasSuccessful():
+        raise Exception('Tests failed!')


### PR DESCRIPTION
* `emailsettings_pop_settings.py`: Fix syntax error
* `gdata/service.py`: Handle HTTP 301 redirects in addition to HTTP 302 ones (see [googlecode #693](https://code.google.com/p/gdata-python-client/issues/detail?id=693)).
* `tests/module_test_runner.py`: Make tests return non-zero status on failures, and increase verbosity.