### PR TITLE
Fix add_issue in client.py

### DIFF
--- a/src/gdata/projecthosting/client.py
+++ b/src/gdata/projecthosting/client.py
@@ -67,8 +67,8 @@ class ProjectHostingClient(gdata.client.GDClient):
       new_entry.status = gdata.projecthosting.data.Status(text=status)
 
     if owner:
-      owner = [gdata.projecthosting.data.Owner(
-          username=gdata.projecthosting.data.Username(text=owner))]
+      new_entry.owner = gdata.projecthosting.data.Owner(
+          username=gdata.projecthosting.data.Username(text=owner))
 
     if labels:
       new_entry.label = [gdata.projecthosting.data.Label(text=label)


### PR DESCRIPTION
Currently, the owner is not set properly when adding an issue. This has already been fixed in a copy of this file we are using for Chromium bugdroid code.