### PR TITLE
Handle setting a forwarding address when creating a filter.

### DIFF
--- a/src/gdata/apps/emailsettings/client.py
+++ b/src/gdata/apps/emailsettings/client.py
@@ -189,7 +189,8 @@ class EmailSettingsClient(gdata.client.GDClient):
   def create_filter(self, username, from_address=None,
                     to_address=None, subject=None, has_the_word=None,
                     does_not_have_the_word=None, has_attachments=None,
-                    label=None, mark_as_read=None, archive=None, **kwargs):
+                    label=None, mark_as_read=None, archive=None,
+                    forward_to=None, **kwargs):
     """Creates a filter with the given properties.
 
     Args:
@@ -211,6 +212,7 @@ class EmailSettingsClient(gdata.client.GDClient):
           messages matching the filter criteria as read.
       archive: Boolean (optional) Whether or not to move messages
           matching to Archived state.
+      forwardTo: (optional) The email address to forward matching messages to.
       kwargs: The other parameters to pass to gdata.client.GDClient.post().
 
     Returns:
@@ -224,7 +226,8 @@ class EmailSettingsClient(gdata.client.GDClient):
         has_the_word=has_the_word,
         does_not_have_the_word=does_not_have_the_word,
         has_attachments=has_attachments, label=label,
-        mark_as_read=mark_as_read, archive=archive)
+        mark_as_read=mark_as_read, archive=archive,
+        forward_to=forward_to)
     return self.post(new_filter, uri, **kwargs)
 
   CreateFilter = create_filter

--- a/src/gdata/apps/emailsettings/data.py
+++ b/src/gdata/apps/emailsettings/data.py
@@ -392,10 +392,18 @@ class EmailSettingsFilter(EmailSettingsEntry):
 
   archive = pyproperty(GetArchive, SetArchive)
 
+  def GetForwardTo(self):
+      return self._GetProperty(FORWARDING_TO)
+
+  def SetForwardTo(self, value):
+      self._SetProperty(FORWARDING_TO, value)
+
+  forward_to = pyproperty(GetForwardTo, SetForwardTo)
+
   def __init__(self, uri=None, from_address=None, to_address=None,
     subject=None, has_the_word=None, does_not_have_the_word=None,
     has_attachments=None, label=None, mark_as_read=None,
-    archive=None, *args, **kwargs):
+    archive=None, forward_to=None, *args, **kwargs):
     """Constructs a new EmailSettingsFilter object with the given arguments.
 
     Args:
@@ -441,6 +449,8 @@ class EmailSettingsFilter(EmailSettingsEntry):
       self.mark_as_read = str(mark_as_read)
     if archive is not None:
       self.archive = str(archive)
+    if forward_to is not None:
+      self.forward_to = forward_to
 
 
 class EmailSettingsSendAsAlias(EmailSettingsEntry):


### PR DESCRIPTION
Currently when creating a filter, the `forwardTo` action is ignored, and it is not possible to create a filter that will forward messages to another address. This fixes that.
