### PR TITLE
Please make the build reproducible.

### DIFF
--- a/pydocs/generate_docs
+++ b/pydocs/generate_docs
@@ -11,4 +11,4 @@
 
 export GOOGLE_APPENGINE=/usr/local/google_appengine/
 export PYTHONPATH=`pwd`/../src:$GOOGLE_APPENGINE
-find ../src/ -name "*.py" | sed "s/\/__init__.py//" | sed "s/\.py//" | sed "s#^\.\.\/src\/##" | sed "s#/#.#g" | xargs pydoc -w
+find ../src/ -name "*.py" | sed "s/\/__init__.py//" | sed "s/\.py//" | sed "s#^\.\.\/src\/##" | sed "s#/#.#g" | LC_ALL=C sort | xargs pydoc -w


### PR DESCRIPTION
Whilst working on the Reproducible Builds effort [0], we noticed
that python-gdata could not be built reproducibly due to non-deterministic
filesystem ordering.

 [0] https://reproducible-builds.org/

Signed-off-by: Chris Lamb <chris@chris-lamb.co.uk>